### PR TITLE
model is failing to serialize on the latest atom

### DIFF
--- a/src/project-view.js
+++ b/src/project-view.js
@@ -248,7 +248,12 @@ const openOnWorkspace = async function _openOnWorkspace (reverseOption) {
       if (!wc.browserWindowOptions) { return; }
       wc.webContents.send(
         'pv-check-if-opened',
-        model, wc.getTitle(),
+        {
+          paths: model.paths,
+          devMode: model.devMode,
+          uuid: model.uuid
+        },
+        wc.getTitle(),
         action
       );
     });


### PR DESCRIPTION
webContents.send is failing to serialize the model object, this change simplifies the object for serialization.

# Pull Request
model is changed to:
{
  paths: model.paths,
  devMode: model.devMode,
  uuid: model.uuid
}
 in webContents.send

## Reason
In the atom version 1.56.0 webContents.send fails to serialize the model object. 
This makes it so projects can't be opened.
The change simplifies to object passed to what's used downstream.

> and if possible provide a screenshot. :+1:

in lieu of a screenshot, here is the console output:
/home/<user>/.atom/…project-view.js:338 Uncaught (in promise) Error: Could not call remote method 'send'. Check that the method signature is correct. Underlying error: Failed to serialize arguments
Underlying stack: Error: Failed to serialize arguments
    at WebContents._.send (electron/js2c/browser_init.js:173:2149)
    at electron/js2c/browser_init.js:233:7839
    at IpcMainImpl.<anonymous> (electron/js2c/browser_init.js:233:4244)
    at IpcMainImpl.emit (events.js:223:5)
    at WebContents.<anonymous> (electron/js2c/browser_init.js:173:8760)
    at WebContents.emit (events.js:223:5)


    at electron/js2c/browser_init.js:233:7867
    at IpcMainImpl.<anonymous> (electron/js2c/browser_init.js:233:4244)
    at IpcMainImpl.emit (events.js:223:5)
    at WebContents.<anonymous> (electron/js2c/browser_init.js:173:8760)
    at WebContents.emit (events.js:223:5)
